### PR TITLE
Remove macOS 13 x86_64 configuration from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13   # Intel → x86_64 wheel
-            cibw_arch: x86_64
           - os: macos-14   # Apple-Silicon → arm64 wheel
             cibw_arch: arm64
 


### PR DESCRIPTION
Removed macOS 13 configuration for x86_64 architecture.